### PR TITLE
Harmonise with puppet and read-only-mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /
 
 EXPOSE 443
 
+ENV SERVER_NAME docker.example.com
+
 CMD ["bash", "/start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 VERSION=latest
 NAME=registry-auth
+NO_CACHE=--no-cache=true
 
 all: build push
 build:
-	docker build --no-cache=true -t $(NAME):$(VERSION) .
-	docker tag -f $(NAME):$(VERSION) docker.sunet.se/$(NAME):$(VERSION)
-update:
-	docker build -t $(NAME):$(VERSION) .
-	docker tag -f $(NAME):$(VERSION) docker.sunet.se/$(NAME):$(VERSION)
+	docker build $(NO_CACHE) -t $(NAME):$(VERSION) -t docker.sunet.se/$(NAME):$(VERSION) .
+update: NO_CACHE=
+update: build
 push:
 	docker push docker.sunet.se/$(NAME):$(VERSION)
 stable:

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ PULL=
 
 all: build push
 build:
-	docker build $(PULL) $(NO_CACHE) -t $(NAME):$(VERSION) -t docker.sunet.se/$(NAME):$(VERSION) .
+	docker build $(PULL) $(NO_CACHE) -t docker.sunet.se/sunet/docker-$(NAME):$(VERSION) .
 update: NO_CACHE=
 update: build
 pull:
 	$(eval PULL=--pull)
 push:
-	docker push docker.sunet.se/$(NAME):$(VERSION)
+	docker push docker.sunet.se/sunet/docker-$(NAME):$(VERSION)
 stable:
-	docker tag -f $(NAME):stable $(NAME):stable-$(date --rfc-3339='date')
-	docker tag -f $(NAME):$(VERSION) $(NAME):stable
+	docker tag -f docker.sunet.se/sunet/docker-$(NAME):stable docker.sunet.se/sunet/docker-$(NAME):stable-$(date --rfc-3339='date')
+	docker tag -f docker.sunet.se/sunet/docker-$(NAME):$(VERSION) docker.sunet.se/sunet/docker-$(NAME):stable

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 VERSION=latest
 NAME=registry-auth
 NO_CACHE=--no-cache=true
+PULL=
 
 all: build push
 build:
-	docker build $(NO_CACHE) -t $(NAME):$(VERSION) -t docker.sunet.se/$(NAME):$(VERSION) .
+	docker build $(PULL) $(NO_CACHE) -t $(NAME):$(VERSION) -t docker.sunet.se/$(NAME):$(VERSION) .
 update: NO_CACHE=
 update: build
+pull:
+	$(eval PULL=--pull)
 push:
 	docker push docker.sunet.se/$(NAME):$(VERSION)
 stable:

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,47 @@ push:
 stable:
 	docker tag -f docker.sunet.se/sunet/docker-$(NAME):stable docker.sunet.se/sunet/docker-$(NAME):stable-$(date --rfc-3339='date')
 	docker tag -f docker.sunet.se/sunet/docker-$(NAME):$(VERSION) docker.sunet.se/sunet/docker-$(NAME):stable
+
+SERVER_NAME=docker.example.com
+CLIENT_NAME=client
+
+$(SERVER_NAME).crt $(SERVER_NAME).key:
+	openssl req -x509 -newkey rsa:4096 -keyout $(SERVER_NAME).key -nodes -out $(SERVER_NAME).crt -days 3650 -subj "/CN=$(SERVER_NAME)"
+$(SERVER_NAME).crt: $(SERVER_NAME).key
+
+$(CLIENT_NAME).csr $(CLIENT_NAME).key:
+	openssl req -new -newkey rsa:4096 -keyout $(CLIENT_NAME).key -nodes -out $(CLIENT_NAME).csr -subj "/CN=$(CLIENT_NAME)"
+$(CLIENT_NAME).csr: $(CLIENT_NAME).key
+
+$(CLIENT_NAME).cert: $(CLIENT_NAME).csr $(SERVER_NAME).crt $(SERVER_NAME).key
+	openssl x509 -req -in $(CLIENT_NAME).csr -CA $(SERVER_NAME).crt -CAkey $(SERVER_NAME).key -set_serial 1 -out $(CLIENT_NAME).cert -days 3650 -sha256
+
+run_registry:
+	docker run -i --rm --name registry registry
+
+run_registry_auth: $(SERVER_NAME).crt $(SERVER_NAME).key
+	docker run -i --rm --name $(NAME) --link registry -p 443:443 -e SERVER_NAME=$(SERVER_NAME) $(DEBUG_registry_auth_ssl) -v $(PWD)/$(SERVER_NAME).key:/etc/ssl/private/$(SERVER_NAME).key -v $(PWD)/$(SERVER_NAME).crt:/etc/ssl/certs/$(SERVER_NAME).crt -v $(PWD)/$(SERVER_NAME).crt:/etc/ssl/certs/$(SERVER_NAME)-chain.crt -v $(PWD)/$(SERVER_NAME).crt:/etc/ssl/certs/$(SERVER_NAME)-client-ca.crt docker.sunet.se/sunet/docker-$(NAME):$(VERSION)
+
+test_registry_auth_ssl_conf: DEBUG_registry_auth_ssl=-v $(PWD)/registry-auth-ssl.conf:/etc/apache2/sites-available/registry-auth-ssl.conf
+test_registry_auth_ssl_conf: run_registry_auth
+
+test_curl: $(CLIENT_NAME).cert $(CLIENT_NAME).key
+	curl -v --fail -X POST --insecure --cacert $(SERVER_NAME).crt --cert $(CLIENT_NAME).cert --key $(CLIENT_NAME).key https://$(SERVER_NAME)/v2/test/blobs/uploads/
+
+install_client_certs: $(SERVER_NAME).crt $(CLIENT_NAME).cert $(CLIENT_NAME).key
+	mkdir -p /etc/docker/certs.d/$(SERVER_NAME)
+	cp $(CLIENT_NAME).cert $(CLIENT_NAME).key  /etc/docker/certs.d/$(SERVER_NAME)/
+	cp $(SERVER_NAME).crt /etc/docker/certs.d/$(SERVER_NAME)/ca.crt
+
+clean_certs:
+	rm -f $(CLIENT_NAME).cert $(CLIENT_NAME).csr $(CLIENT_NAME).key $(SERVER_NAME).crt $(SERVER_NAME).key
+
+set_read_only:
+	docker exec $(NAME) bash -c 'touch /read-only ; apache2ctl -k graceful'
+
+unset_read_only:
+	docker exec $(NAME) bash -c 'rm -f /read-only ; apache2ctl -k graceful'
+
+test:
+	grep $(SERVER_NAME) /etc/hosts
+	./test.sh

--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -39,6 +39,8 @@
     LogLevel warn
     ServerSignature off
 
+    AddDefaultCharset utf-8
+
     ProxyPreserveHost  On
     ProxyRequests      Off
     ProxyPass          /v2  http://registry:5000/v2

--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -1,3 +1,4 @@
+ServerName ${SERVER_NAME}
 <VirtualHost *:443>
     ServerName ${SERVER_NAME}
     SSLEngine On

--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -50,6 +50,8 @@
        Require all denied
     </Location>
 
+    SSLUserName SSL_CLIENT_S_DN
+
     <Location /v2>
        Order deny,allow
        Allow from all

--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -1,5 +1,5 @@
 <VirtualHost *:443>
-    ServerName docker.example.com
+    ServerName ${SERVER_NAME}
     SSLEngine On
     SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
     SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
@@ -7,20 +7,20 @@
     SSLCompression          off
     SSLSessionTickets       off
 
-    SSLCertificateFile /etc/ssl/certs/docker.example.com.crt
-    SSLCertificateChainFile /etc/ssl/certs/docker.example.com-chain.crt
-    SSLCertificateKeyFile /etc/ssl/private/docker.example.com.key
+    SSLCertificateFile /etc/ssl/certs/${SERVER_NAME}.crt
+    SSLCertificateChainFile /etc/ssl/certs/${SERVER_NAME}-chain.crt
+    SSLCertificateKeyFile /etc/ssl/private/${SERVER_NAME}.key
 
     # Everyone who wants to POST something have to present a client cert
     # that is signed by this CA.
-    SSLCACertificateFile /etc/ssl/certs/docker.example.com-client-ca.crt
+    SSLCACertificateFile /etc/ssl/certs/${SERVER_NAME}-client-ca.crt
     SSLVerifyClient optional
     SSLVerifyDepth 1
     DocumentRoot /var/www/
 
     ServerAdmin noc@example.com
 
-    Header set Host "docker.example.com"
+    Header set Host "${SERVER_NAME}"
     RequestHeader set X-Forwarded-Proto "https"
 
     # HSTS (mod_headers is required) (15768000 seconds = 6 months)

--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -55,12 +55,20 @@
     <Location /v2>
        Order deny,allow
        Allow from all
-       <RequireAll>
-          Require ssl
-          <RequireAny>
+       <If "-f '/read-only'">
+          <RequireAll>
+             Require ssl
              Require method GET
-             Require ssl-verify-client
-          </RequireAny>
-       </RequireAll>
+          </RequireAll>
+       </If>
+       <Else>
+          <RequireAll>
+          Require ssl
+             <RequireAny>
+                Require method GET
+                Require ssl-verify-client
+             </RequireAny>
+          </RequireAll>
+       </Else>
     </Location>
 </VirtualHost>

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 mkdir -p /var/lock/apache2 /var/run/apache2
 rm /var/run/apache2/apache2.pid
 env APACHE_LOCK_DIR=/var/lock/apache2 APACHE_RUN_DIR=/var/run/apache2 APACHE_PID_FILE=/var/run/apache2/apache2.pid APACHE_RUN_USER=www-data APACHE_RUN_GROUP=www-data APACHE_LOG_DIR=/var/log/apache2 apache2 -DFOREGROUND

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 mkdir -p /var/lock/apache2 /var/run/apache2
 rm /var/run/apache2/apache2.pid
-env APACHE_LOCK_DIR=/var/lock/apache2 APACHE_RUN_DIR=/var/run/apache2 APACHE_PID_FILE=/var/run/apache2/apache2.pid APACHE_RUN_USER=www-data APACHE_RUN_GROUP=www-data APACHE_LOG_DIR=/var/log/apache2 apache2 -DFOREGROUND
+
+exec env APACHE_LOCK_DIR=/var/lock/apache2 APACHE_RUN_DIR=/var/run/apache2 APACHE_PID_FILE=/var/run/apache2/apache2.pid APACHE_RUN_USER=www-data APACHE_RUN_GROUP=www-data APACHE_LOG_DIR=/var/log/apache2 apache2 -DFOREGROUND

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+function failure
+{
+	kill "$REG"
+	kill "$REG_AUTH"
+
+	echo "FAILURE!"
+}
+
+trap failure EXIT
+
+docker rm -fv registry-auth registry 2>/dev/null || true
+
+make run_registry >&/dev/null &
+REG=$!
+
+sleep 2
+
+make run_registry_auth >&/dev/null &
+REG_AUTH=$!
+
+sleep 2
+
+make test_curl
+
+make set_read_only
+
+if make test_curl ; then
+	echo "FAILED: test_curl in read-only mode!"
+	exit 1
+fi
+
+make unset_read_only
+
+make test_curl
+
+kill "$REG"
+kill "$REG_AUTH"
+
+trap - EXIT


### PR DESCRIPTION
This harmonizes this docker container with whats in puppet to run this
container, removing the need to use a template to render
registry-auth-ssl.conf, and using a environment variable to configure it
instead.

This also implements a mechanism to put the proxy in read-only-mode so we
can, in the future, implement online registry cleaning.