### PR TITLE
Move ErrorLog statement to global scope

### DIFF
--- a/registry-auth-ssl.conf
+++ b/registry-auth-ssl.conf
@@ -1,4 +1,8 @@
 ServerName ${SERVER_NAME}
+
+# Write to STDERR
+ErrorLog /proc/self/fd/2
+
 <VirtualHost *:443>
     ServerName ${SERVER_NAME}
     SSLEngine On
@@ -30,9 +34,6 @@ ServerName ${SERVER_NAME}
     ProxyRequests On
 
     AddDefaultCharset utf-8
-
-    # Write to STDERR
-    ErrorLog /proc/self/fd/2
 
     # Write to STDOUT
     CustomLog /proc/self/fd/1 combined


### PR DESCRIPTION
This is so any global errors also ends up in stderr. This is so fatal
errors from for example configuration is exposed where it can be seen.